### PR TITLE
modify wheels controller type and add gains

### DIFF
--- a/pepper_control/config/pepper_trajectory_control.yaml
+++ b/pepper_control/config/pepper_trajectory_control.yaml
@@ -41,8 +41,12 @@ pepper_dcm:
     joints:
       - RHand
   Wheels_controller:
-    type: position_controllers/JointTrajectoryController
+    type: effort_controllers/JointTrajectoryController
     joints:
       - WheelFL
       - WheelB
-      - WheelFR                  
+      - WheelFR  
+    gains:
+      WheelFL: {p: 10000000.0, i: 0.0, d: 1.0} 
+      WheelB: {p: 10000000.0, i: 0.0, d: 1.0}       
+      WheelFR: {p: 10000000.0, i: 0.0, d: 1.0}


### PR DESCRIPTION
Hi, 
when I tried `roslaunch pepper_gazebo_plugin  pepper_gazebo_plugin_Y20.launch` with https://github.com/ros-naoqi/pepper_robot/pull/28,

```
[ERROR] [1475455830.745881723]: Could not find joint 'WheelFL' in 'hardware_interface::PositionJointInterface'.
[ERROR] [1475455830.746165374]: Failed to initialize the controller
[ERROR] [1475455830.746211869]: Initializing controller '/pepper_dcm/Wheels_controller' failed
[ERROR] [WallTime: 1475455831.747561] [0.000000] Failed to load /pepper_dcm/Wheels_controller
```

appeared, and I modified `type: position_controllers/JointTrajectoryController` to `type: effort_controllers/JointTrajectoryController` .

However, after that change,

```
[ERROR] [1475456337.894138094]: No p gain specified for pid.  Namespace: /pepper_dcm/Wheels_controller/gains/WheelFL
[ WARN] [1475456337.894267999]: Failed to initialize PID gains from ROS parameter server.
```

appeared. Then, I added gains (from pepper_description/urdf/pepper1.0_generated/pepperGazebo.xacro)

I checked Pepper's wheels move by `rosrun rqt_robot_steering rqt_robot_steering rqt_robot_steering rqt_robot_steering` .
Still pepper's wheels don't move as they should (ex: when sending /cmd_vel 0.2 0 0, pepper rotates clockwise), but I think there is something wrong omni wheels definition. (I'd like to study it next.)

If there is any problem, please let me know.
