### PR TITLE
[pepper_gazebo_plugin] enable to launch pepper_control_trajectory_all.launch

### DIFF
--- a/pepper_gazebo_plugin/launch/pepper_gazebo_plugin_Y20.launch
+++ b/pepper_gazebo_plugin/launch/pepper_gazebo_plugin_Y20.launch
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="launch_control_trajectory_all" default="true"/>
   <!-- Load the URDF Model -->
   <include file="$(find pepper_description)/launch/pepper_upload.launch" />  
   <!-- We resume the logic in empty_world.launch, changing only the name of the world to be launched -->
@@ -11,7 +12,8 @@
 
   <!-- Call Pepper Robot Trajectory Controller -->
 
-  <include file="$(find pepper_control)/launch/pepper_control_trajectory.launch"/>
+  <include file="$(find pepper_control)/launch/pepper_control_trajectory.launch" unless="$(arg launch_control_trajectory_all)"/>
+  <include file="$(find pepper_control)/launch/pepper_control_trajectory_all.launch" if="$(arg launch_control_trajectory_all)"/>
 <!--
   <include file="$(find pepper_control)/launch/pepper_control_position.launch"/>
 -->


### PR DESCRIPTION
I added the function of selecting launching program (pepper_control_position.launch or pepper_control_position_all.launch). 
If there is any problem, please let me know.

`roslaunch pepper_gazebo_plugin pepper_gazebo_plugin_Y20.launch launch_control_trajectory_all:=true`

```
[INFO] [WallTime: 1476320750.163967] [89.405000] Started controllers: /pepper_dcm/RightArm_controller, /pepper_dcm/LeftArm_controller, /pepper_dcm/RightHand_controller, /pepper_dcm/LeftHand_controller, /pepper_dcm/Head_controller, /pepper_dcm/Pelvis_controller, /pepper_dcm/WheelFL_controller, /pepper_dcm/WheelFR_controller, /pepper_dcm/WheelB_controller, /pepper_dcm/joint_state_controller
```

`roslaunch pepper_gazebo_plugin pepper_gazebo_plugin_Y20.launch launch_control_trajectory_all:=false`

```
[INFO] [WallTime: 1476320869.622060] [0.000000] Started controllers: /pepper_dcm/RightArm_controller, /pepper_dcm/LeftArm_controller, /pepper_dcm/RightHand_controller, /pepper_dcm/LeftHand_controller, /pepper_dcm/joint_state_controller
```
