### PR TITLE
[pepper_control] delete wheel controllers from pepper_control_trajectory_all.launch

### DIFF
--- a/pepper_control/launch/pepper_control_trajectory_all.launch
+++ b/pepper_control/launch/pepper_control_trajectory_all.launch
@@ -13,8 +13,5 @@
       /pepper_dcm/LeftHand_controller
       /pepper_dcm/Head_controller
       /pepper_dcm/Pelvis_controller
-      /pepper_dcm/WheelFL_controller
-      /pepper_dcm/WheelFR_controller
-      /pepper_dcm/WheelB_controller
       /pepper_dcm/joint_state_controller "/>
 </launch>


### PR DESCRIPTION
I'd like to  use  
```
/pepper_dcm/Head_controller                                                           
/pepper_dcm/Pelvis_controller 
```
(I'd like to move Pepper's all parts in gazebo environment.)

However, 
```
 /pepper_dcm/WheelFL_controller                                                        
 /pepper_dcm/WheelFR_controller                                                        
 /pepper_dcm/WheelB_controller 
```
don't seem to be required in https://github.com/ros-naoqi/pepper_robot/pull/31.
(Pepper seems to be likely to bend down because of some force of wheels.)

That's why In this pull-request, I deleted wheel controllers.
Instead, I can modify pepper_control_trajectory.launch (adding ``` /pepper_dcm/Head_controller and  /pepper_dcm/Pelvis_controller```)
If there is any problem, please let me know.